### PR TITLE
Starts the video muted, otherwise it wont actually autoplay.

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
 <body>
     <div align="center">
-        <video autoplay controls="controls" id="myvideo"/> 
+        <video autoplay muted controls="controls" id="myvideo"/> 
             <source src="rr.mp4" type="video/mp4"> 
         </video> 
     </div>


### PR DESCRIPTION
Modern browsers require permission to automatically play videos that include sound.